### PR TITLE
Add other dummy keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,23 +78,23 @@ async function validateToken(token: string) {
 
 ### Turnstile Component Props
 
-| Prop             | Type                                          | Default              | Description                         |
-| ---------------- | --------------------------------------------- | -------------------- | ----------------------------------- |
-| `siteKey`        | `string`                                      | Required             | Your Cloudflare Turnstile site key  |
-| `onVerify`       | `(token: string) => void`                     | -                    | Callback when verification succeeds |
-| `onError`        | `(error: unknown) => void`                    | -                    | Callback when an error occurs       |
-| `onExpire`       | `() => void`                                  | -                    | Callback when the token expires     |
-| `onLoad`         | `() => void`                                  | -                    | Callback when the widget loads      |
-| `theme`          | `'light' \| 'dark' \| 'auto'`                 | `'auto'`             | Widget theme                        |
-| `size`           | `'normal' \| 'compact'`                       | `'normal'`           | Widget size                         |
-| `appearance`     | `'always' \| 'execute' \| 'interaction-only'` | `'always'`           | When to show the widget             |
-| `retry`          | `'auto' \| 'never'`                           | `'auto'`             | Retry behavior on failure           |
-| `retryInterval`  | `number`                                      | `8000`               | Milliseconds between retries        |
-| `refreshExpired` | `'auto' \| 'manual' \| 'never'`               | `'auto'`             | Token refresh behavior              |
-| `language`       | `string`                                      | -                    | Widget language code                |
-| `id`             | `string`                                      | `'turnstile-widget'` | Container element ID                |
-| `className`      | `string`                                      | -                    | Additional CSS classes              |
-| `sandbox`        | `boolean`                                     | `false`              | Enable sandbox mode                 |
+| Prop             | Type                                                                    | Default              | Description                         |
+|------------------|-------------------------------------------------------------------------|----------------------|-------------------------------------|
+| `siteKey`        | `string`                                                                | Required             | Your Cloudflare Turnstile site key  |
+| `onVerify`       | `(token: string) => void`                                               | -                    | Callback when verification succeeds |
+| `onError`        | `(error: unknown) => void`                                              | -                    | Callback when an error occurs       |
+| `onExpire`       | `() => void`                                                            | -                    | Callback when the token expires     |
+| `onLoad`         | `() => void`                                                            | -                    | Callback when the widget loads      |
+| `theme`          | `'light' \| 'dark' \| 'auto'`                                           | `'auto'`             | Widget theme                        |
+| `size`           | `'normal' \| 'compact'`                                                 | `'normal'`           | Widget size                         |
+| `appearance`     | `'always' \| 'execute' \| 'interaction-only'`                           | `'always'`           | When to show the widget             |
+| `retry`          | `'auto' \| 'never'`                                                     | `'auto'`             | Retry behavior on failure           |
+| `retryInterval`  | `number`                                                                | `8000`               | Milliseconds between retries        |
+| `refreshExpired` | `'auto' \| 'manual' \| 'never'`                                         | `'auto'`             | Token refresh behavior              |
+| `language`       | `string`                                                                | -                    | Widget language code                |
+| `id`             | `string`                                                                | `'turnstile-widget'` | Container element ID                |
+| `className`      | `string`                                                                | -                    | Additional CSS classes              |
+| `sandbox`        | `boolean` \| `pass` \| `block` \| `pass-invisible` \| `block-invisible` | `false`              | Enable sandbox mode                 |
 
 ### Server Validation Options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "next-turnstile",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-turnstile",
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.0.0",
         "@typescript-eslint/eslint-plugin": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-turnstile",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cloudflare Turnstile integration for Next.js applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/Turnstile.tsx
+++ b/src/client/Turnstile.tsx
@@ -70,13 +70,28 @@ export const Turnstile: React.FC<TurnstileProps> = ({
     return cleanup;
   }, [siteKey, sandbox]);
 
+  const sandboxDummyKey = () => {
+    switch (sandbox) {
+      case "pass":
+        return "1x00000000000000000000AA";
+      case "block":
+        return "2x00000000000000000000AB";
+      case "pass-invisible":
+        return "1x00000000000000000000BB";
+      case "block-invisible":
+        return "2x00000000000000000000BB";
+    }
+
+    return "1x00000000000000000000AA";
+  };
+
   const renderWidget = () => {
     if (!containerRef.current || !window.turnstile) return;
 
     cleanup();
 
     widgetRef.current = window.turnstile.render(containerRef.current, {
-      sitekey: sandbox ? "1x00000000000000000000AA" : siteKey,
+      sitekey: sandbox ? sandboxDummyKey() : siteKey,
       callback: onVerify,
       "error-callback": onError,
       "expired-callback": onExpire,

--- a/src/server/validate.ts
+++ b/src/server/validate.ts
@@ -9,8 +9,21 @@ export async function validateTurnstileToken({
 }: TurnstileValidateOptions): Promise<TurnstileValidateResponse> {
   const endpoint = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
+  const sandboxDummyKey = () => {
+    switch (sandbox) {
+      case "pass":
+        return "1x0000000000000000000000000000000AA";
+      case "fail":
+        return "2x0000000000000000000000000000000AA";
+      case "error":
+        return "3x0000000000000000000000000000000AA";
+    }
+
+    return "1x0000000000000000000000000000000AA";
+  };
+
   const formData = new URLSearchParams({
-    secret: sandbox ? "1x0000000000000000000000000000000AA" : secretKey,
+    secret: sandbox ? sandboxDummyKey() : secretKey,
     response: token,
     ...(remoteip && { remoteip }),
     ...(idempotencyKey && { idempotency_key: idempotencyKey }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface TurnstileValidateOptions {
   secretKey: string;
   remoteip?: string;
   idempotencyKey?: string;
-  sandbox?: boolean;
+  sandbox?: "pass" | "fail" | "error" | boolean;
 }
 
 export interface TurnstileValidateResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface TurnstileProps {
   execution?: "render" | "execute";
   cData?: string;
   language?: string;
-  sandbox?: boolean;
+  sandbox?: "pass" | "block" | "pass-invisible" | "block-invisible" | boolean;
 }
 
 export interface TurnstileValidateOptions {


### PR DESCRIPTION
This pull request introduces a version bump for the package and enhances the functionality of the `Turnstile` component by improving the handling of the `sandbox` prop. The most significant changes include adding a new utility function for sandbox dummy keys, updating the `sandbox` prop type, and modifying the logic for rendering the widget. This allows the usage of other dummy keys which are able to always pass, always block and be visible or invisible.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.0.2` to `1.0.3` to reflect the new changes.

### Enhancements to the `Turnstile` Component:
* [`src/client/Turnstile.tsx`](diffhunk://#diff-ae6c90e95ca5cf98984e68655503ec27532e2fb1779f6fc452daa824bfbc022cR73-R94): Added a new `sandboxDummyKey` utility function to dynamically determine the dummy key based on the `sandbox` mode. Updated the `renderWidget` logic to use this function for setting the `sitekey` when `sandbox` is enabled.
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL21-R21): Updated the `sandbox` prop type in the `TurnstileProps` interface to accept specific string values (`"pass"`, `"block"`, `"pass-invisible"`, `"block-invisible"`) in addition to `boolean`, providing more granular control over sandbox behavior.