### PR TITLE
Add missing attributes to server sandbox options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ async function validateToken(token: string) {
 
 ### Server Validation Options
 
-| Option           | Type      | Required | Description               |
-| ---------------- | --------- | -------- | ------------------------- |
-| `token`          | `string`  | Yes      | The token from the client |
-| `secretKey`      | `string`  | Yes      | Your Turnstile secret key |
-| `remoteip`       | `string`  | No       | User's IP address         |
-| `idempotencyKey` | `string`  | No       | Unique request identifier |
-| `sandbox`        | `boolean` | No       | Enable sandbox mode       |
+| Option           | Type                                    | Required | Description               |
+|------------------|-----------------------------------------|----------|---------------------------|
+| `token`          | `string`                                | Yes      | The token from the client |
+| `secretKey`      | `string`                                | Yes      | Your Turnstile secret key |
+| `remoteip`       | `string`                                | No       | User's IP address         |
+| `idempotencyKey` | `string`                                | No       | Unique request identifier |
+| `sandbox`        | `boolean`\| `pass` \| `fail` \| `error` | No       | Enable sandbox mode       |
 
 ## Advanced Usage
 


### PR DESCRIPTION
Hi, this is a follow-up to #7 where I forgot to add the sandbox options for the server.
I also noticed that the package on npm for whatever reason doesn't have these types